### PR TITLE
Remove unnecessary allocations and special-casing for @/&

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
+# slug
 A small library for generating [slugs][wikipedia] from unicode strings.
 
 Documentation: https://stebalien.github.io/slug-rs/slug
 
 [wikipedia]: https://en.wikipedia.org/wiki/Semantic_URL#Slug
+
+## Usage
+```rust
+extern crate slug;
+use slug::slugify;
+
+let slug = slugify("Hello world");
+```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,12 +56,6 @@ pub fn slugify<S: AsRef<str>>(s: S) -> String {
         }
     }
 
-    // Remove trailing / if there is one
-    match slug.pop() {
-        Some(c) => { if c != '-' as u8 { slug.push(c); } },
-        None => ()
-    }
-
     // It's not really unsafe in practice, we know we have ASCII
     let mut string = unsafe { String::from_utf8_unchecked(slug) };
     if string.ends_with('-') {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@ use std::ascii::AsciiExt;
 /// ```
 pub fn slugify<S: AsRef<str>>(s: S) -> String {
     let s = s.as_ref();
-    let mut slug = Vec::with_capacity(s.len());
+    let mut slug: Vec<u8> = Vec::with_capacity(s.len());
     // Starts with true to avoid leading -
     let mut prev_is_dash = true;
     {
@@ -28,17 +28,17 @@ pub fn slugify<S: AsRef<str>>(s: S) -> String {
             match x {
                 'a'...'z' | '0'...'9' => {
                     prev_is_dash = false;
-                    slug.push(x);
+                    slug.push(x as u8);
                 },
                 'A'...'Z' => {
                     prev_is_dash = false;
                     // Manual lowercasing as Rust to_lowercase() is unicode
                     // aware and therefore much slower
-                    slug.push(((x as u8) - ('A' as u8) + ('a' as u8)) as char);
+                    slug.push(((x as u8) - ('A' as u8) + ('a' as u8)));
                 },
                 _ => {
                     if !prev_is_dash {
-                        slug.push('-');
+                        slug.push('-' as u8);
                         prev_is_dash = true;
                     }
                 }
@@ -58,9 +58,10 @@ pub fn slugify<S: AsRef<str>>(s: S) -> String {
 
     // Remove trailing / if there is one
     match slug.pop() {
-        Some(c) => { if c != '-' { slug.push(c); } },
+        Some(c) => { if c != '-' as u8 { slug.push(c); } },
         None => ()
     }
 
-    slug.into_iter().collect::<String>()
+    // It's not really unsafe in practice, we know we have ASCII
+    unsafe { String::from_utf8_unchecked(slug) }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,8 @@
 extern crate unidecode;
+
 use unidecode::unidecode_char;
 use std::ascii::AsciiExt;
+use std::iter::FromIterator;
 
 /// Convert any unicode string to an ascii "slug" (useful for file names/url components)
 ///
@@ -14,60 +16,50 @@ use std::ascii::AsciiExt;
 /// assert_eq!(slugify("test\nit   now!"), "test-it-now");
 /// assert_eq!(slugify("  --test_-_cool"), "test-cool");
 /// assert_eq!(slugify("Æúű--cool?"), "aeuu-cool");
-/// assert_eq!(slugify("You & Me"), "you-and-me");
-/// assert_eq!(slugify("user@example.com"), "user-at-example-com");
+/// assert_eq!(slugify("You & Me"), "you-me");
+/// assert_eq!(slugify("user@example.com"), "user-example-com");
 /// ```
 pub fn slugify<S: AsRef<str>>(s: S) -> String {
-    let s = s.as_ref();
-    let mut string = String::with_capacity(s.len());
+    let s = s.as_ref().trim();
+    let mut slug = Vec::with_capacity(s.len());
+    // Starts with true to avoid leading -
+    let mut prev_is_dash = true;
     {
-        let output = unsafe { string.as_mut_vec() };
-        let mut dash = true;
-
-        let mut push_char = |c: char| {
-            match c {
-                'a'...'z' | '0'...'9' | 'A'...'Z' => {
-                    match c {
-                        'a'...'z' | '0'...'9' => output.push(c as u8),
-                        'A'...'Z' => output.push((c as u8) - ('A' as u8) + ('a' as u8)),
-                        _ => unreachable!(),
-                    }
-                    dash = false;
-                }
+        let mut push_char = |x: char| {
+            match x {
+                'a'...'z' | '0'...'9' => {
+                    prev_is_dash = false;
+                    slug.push(x);
+                },
+                'A'...'Z' => {
+                    prev_is_dash = false;
+                    // Manual lowercasing as Rust to_lowercase() is unicode
+                    // aware and therefore much slower
+                    slug.push(((x as u8) - ('A' as u8) + ('a' as u8)) as char);
+                },
                 _ => {
-                    if dash {
-                        match c {
-                            '@' => output.extend(b"at-"),
-                            '&' => output.extend(b"and-"),
-                            _ => {}
-                        }
-                    } else {
-                        match c {
-                            '@' => output.extend(b"-at-"),
-                            '&' => output.extend(b"-and-"),
-                            _ => output.push(b'-'),
-                        }
-                        dash = true;
+                    if !prev_is_dash {
+                        slug.push('-');
+                        prev_is_dash = true;
                     }
                 }
-            }
+            };
         };
+
         for c in s.chars() {
             if c.is_ascii() {
-                (push_char)(c);
+                push_char(c);
             } else {
-                for c in unidecode_char(c).chars() {
-                    (push_char)(c);
+                for cx in unidecode_char(c).chars() {
+                    push_char(cx);
                 }
             }
         }
     }
 
-    if string.ends_with('-') {
-        string.pop();
+    let mut res = String::from_iter(slug);
+    if res.ends_with('-') {
+        res.pop();
     }
-
-    // We likely reserved more space than needed.
-    string.shrink_to_fit();
-    string
+    res
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,5 +63,11 @@ pub fn slugify<S: AsRef<str>>(s: S) -> String {
     }
 
     // It's not really unsafe in practice, we know we have ASCII
-    unsafe { String::from_utf8_unchecked(slug) }
+    let mut string = unsafe { String::from_utf8_unchecked(slug) };
+    if string.ends_with('-') {
+        string.pop();
+    }
+    // We likely reserved more space than needed.
+    string.shrink_to_fit();
+    string
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,6 @@ extern crate unidecode;
 
 use unidecode::unidecode_char;
 use std::ascii::AsciiExt;
-use std::iter::FromIterator;
 
 /// Convert any unicode string to an ascii "slug" (useful for file names/url components)
 ///
@@ -20,7 +19,7 @@ use std::iter::FromIterator;
 /// assert_eq!(slugify("user@example.com"), "user-example-com");
 /// ```
 pub fn slugify<S: AsRef<str>>(s: S) -> String {
-    let s = s.as_ref().trim();
+    let s = s.as_ref();
     let mut slug = Vec::with_capacity(s.len());
     // Starts with true to avoid leading -
     let mut prev_is_dash = true;
@@ -43,23 +42,25 @@ pub fn slugify<S: AsRef<str>>(s: S) -> String {
                         prev_is_dash = true;
                     }
                 }
-            };
+            }
         };
 
         for c in s.chars() {
             if c.is_ascii() {
-                push_char(c);
+                (push_char)(c);
             } else {
                 for cx in unidecode_char(c).chars() {
-                    push_char(cx);
+                    (push_char)(cx);
                 }
             }
         }
     }
 
-    let mut res = String::from_iter(slug);
-    if res.ends_with('-') {
-        res.pop();
+    // Remove trailing / if there is one
+    match slug.pop() {
+        Some(c) => { if c != '-' { slug.push(c); } },
+        None => ()
     }
-    res
+
+    slug.into_iter().collect::<String>()
 }


### PR DESCRIPTION
I was looking at making the slug filter for Tera and found this crate.

I removed the special casing for @ and & as I've never seen that used before and some slug functions even remove conjunctions like `and` (from https://en.wikipedia.org/wiki/Semantic_URL#Slug)

I get pretty much the exact same speed with that version
