### PR TITLE
refactor: remove the only unsafe block

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@ pub fn slugify_owned(s: String) -> String {
 
 // avoid unnecessary monomorphizations
 fn _slugify(s: &str) -> String {
-    let mut slug: Vec<u8> = Vec::with_capacity(s.len());
+    let mut slug = String::with_capacity(s.len());
     // Starts with true to avoid leading -
     let mut prev_is_dash = true;
     {
@@ -38,17 +38,17 @@ fn _slugify(s: &str) -> String {
             match x {
                 b'a'..=b'z' | b'0'..=b'9' => {
                     prev_is_dash = false;
-                    slug.push(x);
+                    slug.push(x.into());
                 }
                 b'A'..=b'Z' => {
                     prev_is_dash = false;
                     // Manual lowercasing as Rust to_lowercase() is unicode
                     // aware and therefore much slower
-                    slug.push(x - b'A' + b'a');
+                    slug.push((x - b'A' + b'a').into());
                 }
                 _ => {
                     if !prev_is_dash {
-                        slug.push(b'-');
+                        slug.push('-');
                         prev_is_dash = true;
                     }
                 }
@@ -66,12 +66,10 @@ fn _slugify(s: &str) -> String {
         }
     }
 
-    // It's not really unsafe in practice, we know we have ASCII
-    let mut string = unsafe { String::from_utf8_unchecked(slug) };
-    if string.ends_with('-') {
-        string.pop();
+    if slug.ends_with('-') {
+        slug.pop();
     }
     // We likely reserved more space than needed.
-    string.shrink_to_fit();
-    string
+    slug.shrink_to_fit();
+    slug
 }


### PR DESCRIPTION
This PR proposes to remove the only use of `unsafe` in this crate.

Given `unsafe` was only used for calling the `unsafe` `String::from_utf8_unchecked()` function, whose goal was to improve performance, I did benchmark the new implementation (on an x86 machine), using the benchmarks already present, which require `nightly`.

Interestingly enough, I found that the implementation *without* `unsafe` performed the same or better when running the benchmarks with `cargo +nightly-2024-07-27 bench`, but significantly (10–20 %) worse with `cargo +nightly-2024-07-28 bench` (the `nightly` from the day after).

I could not however reproduce this difference when implementing the same benchmarks manually as a regular binary (which I am of course running with `--release`); the implementation *without* `unsafe` was at least as fast in that setup:

```rust
use std::{hint::black_box, time::Instant};

use slug::slugify;

fn main() {
    const ITER_COUNT: usize = 10_000_000;

    let start = Instant::now();

    for _ in 0..ITER_COUNT {
        black_box(slugify(black_box("Test Slug2!!")));
        black_box(slugify(black_box("Æúűűűű--cool?")));
        black_box(slugify(black_box("long long long long      long")));
    }

    let duration = start.elapsed();
    println!(
        "Took {:.2} ns per iteration",
        duration.as_nanos() as f32 / ITER_COUNT as f32,
    );
}
```
